### PR TITLE
Update psych version to fix JRuby load issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,4 @@ group :rdoc do
   gem "rdoc", "6.5.0"
 end
 
-gem "psych", "!= 5.1.1", "!= 5.1.0" # https://github.com/ruby/psych/issues/655
+gem "psych", "5.1.1.1"


### PR DESCRIPTION
Psych 5.1.1 fails to load on JRuby 9.x issue has been solved on the latest Psych release:

https://github.com/ruby/psych/releases/tag/v5.1.1.1